### PR TITLE
Wait response of Close Session command

### DIFF
--- a/src/ruipmi.rs
+++ b/src/ruipmi.rs
@@ -305,7 +305,9 @@ impl IpmiClient {
         self.out_seq = self.out_seq.wrapping_add(1);
         self.rq_seq = self.rq_seq.wrapping_add(1);
         // best-effort
-        let _ = self.send(&msg).await;
+        if let Ok(_) = self.send(&msg).await {
+            let _ = self.recv(1024).await;
+        }
         self.established = false;
         Ok(())
     }


### PR DESCRIPTION
Without this PR, after the client calls the `close` method, it will send an ICMP `Destination unreachable (Port unreachable)` to the BMC because the client socket has been closed when the response arrives.